### PR TITLE
Add recommendations for vscode extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,9 @@ src/_public/*
 *.DS_Store
 .fake
 .ionide
-.vscode
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "editorconfig.editorconfig"
+    ]
+}


### PR DESCRIPTION
As mentioned [here](https://github.com/AvaloniaCommunity/Avalonia.FuncUI.Docs/issues/1#issuecomment-636420234) it could be helpful for contributors to include the editorconfig extension for vscode in the repository.

If editor specific stuff is okay in this repository, this pull-requests adds that.