### PR TITLE
Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,43 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+
+# The image referenced above includes a non-root user with sudo access. Add
+# the "remoteUser" property to devcontainer.json to use it. On Linux, the container
+# user's GID/UIDs will be updated to match your local UID/GID when using the image
+# or dockerFile property. Update USER_UID/USER_GID below if you are using the
+# dockerComposeFile property or want the image itself to start with different ID
+# values. See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+ARG USERNAME=vscode
+
+# Configure apt and install packages
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git openssh-client less iproute2 procps lsb-release \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Helpful tools
+    && apt-get -y install --no-install-recommends bash-completion nano \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add autocomplete for git in terminal
+RUN echo "source /usr/share/bash-completion/completions/git" > /root/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/dotnetcore-3.1-fsharp
+{
+	"name": "F# (.NET Core 3.1)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	//
+	// .NET Core is now the default for F# in .NET Core 3.0+
+	// However, .NET Core scripting is not the default yet. Set that to true.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"FSharp.useSdkScripts":true
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+        "ionide.ionide-fsharp",
+        "ms-dotnettools.csharp",
+        "editorconfig.editorconfig"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8080],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "dotnet tool restore && dotnet restore",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "editorconfig.editorconfig"
+        "editorconfig.editorconfig",
+        "ms-vscode-remote.remote-containers"
     ]
 }


### PR DESCRIPTION
I added a devcontainer to this repository, which can be used to easily start working at a repository with everything preconfigured. All necessary extensions are installed and you should be able to develop even without having .NET Core installed on your machine, because it is installed inside the container. The only thing you need in your local VSCode instance is the Remote-Container extension, which is recommended now.

This could also simplify things when [GitHub CodeSpaces](https://github.com/features/codespaces/) are available.

I started with the definitions of this repository:
https://github.com/microsoft/vscode-dev-containers/tree/master/containers/dotnetcore-3.1-fsharp/.devcontainer

But I tweaked it a bit for my own projects, because I missed an command line editor (I personally prefer nano) and command line completion, so I added that.

I also forwarded the 8080 port for fornax to work properly from inside the container and added the extensions I think are needed. I'm not quite sure about the C# extension to be honest, I guess this is only needed for debugging, but I don't know :smile: 

I'm happy to hear (read) your thoughts on this :)