### PR TITLE
Remove warnings

### DIFF
--- a/fsharplint.json
+++ b/fsharplint.json
@@ -1,0 +1,10 @@
+
+{
+    "recordFieldNames": {
+        "enabled": true,
+        "config": {
+            "naming": "CamelCase",
+            "underscores": "None"
+        }
+    }
+}

--- a/src/loaders/controlloader.fsx
+++ b/src/loaders/controlloader.fsx
@@ -20,7 +20,7 @@ type ControlGroup =
         | "primitives" -> Primitives
         | _ -> Uncategorized
 
-    member this.ToString() =
+    override this.ToString() =
         match this with
         | Controls      -> "Controls"
         | Primitives  -> "Primitives"

--- a/src/loaders/guideloader.fsx
+++ b/src/loaders/guideloader.fsx
@@ -21,7 +21,7 @@ type GuideCategory =
         | "advanced" -> Advanced
         | _ -> Uncategorized
 
-    member this.ToString() =
+    override this.ToString() =
         match this with
         | Beginner      -> "Beginner"
         | Intermediate  -> "Intermediate"


### PR DESCRIPTION
I got some warnings in some loaders.

To fix that I added a fsharplint.json and changed the wanted naming convention for record fields to camelCase.
Also there were two cases where the ToString implementation hid the underlying one, so I changed that to override. 