### PR TITLE
Set baseUrl depending on watch or build

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ Fornax offers a watch command that allows you to preview the website as you deve
 
 > If you want to live reload your changes (instead of an F5 on each change) you can select set to false the `siteContent.Add({ disableLiveRefresh = true })` setting inside `loaders/guideloader.fsx` and `loaders/postloader.fsx`
 
-> to prevent issues with links locally please change the follwing line `baseUrl = "/Avalonia.FuncUI/"` to `baseUrl = "/"` while in development in `loaders/globalloader.fsx`
-
 ```
 dotnet tool restore
 cd src

--- a/src/loaders/globalloader.fsx
+++ b/src/loaders/globalloader.fsx
@@ -8,10 +8,18 @@ type SiteInfo = {
 }
 
 let loader (projectRoot: string) (siteContent: SiteContents) =
+
+// Determine baseUrl based on build or watch
+#if FORNAX && WATCH
+    let baseUrl = "/"
+#else
+    let baseUrl = "/Avalonia.FuncUI.Docs/"
+#endif
+
     siteContent.Add(
         { title = "Avalonia.FuncUI"
           description = "Avalonia.FuncUI Website"
           showSideBar = true
-          baseUrl = "/Avalonia.FuncUI.Docs/"
+          baseUrl = baseUrl
         })
     siteContent


### PR DESCRIPTION
To simplify working with the docs, I added conditional compilation so
that in WatchMode (dev) the url is "/" and in BuildMode (live) the url
is "/Avalonia.FuncUi.Docs/".

With that manual changes are no longer necessary to start working (I hope :smile:).