### PR TITLE
Fix images in StackPanel docs

### DIFF
--- a/src/controls/StackPanel.md
+++ b/src/controls/StackPanel.md
@@ -27,7 +27,7 @@ StackPanel.create [
 
 **Example**
 
-![StackPanel](/images/controls/stackpanel/basic.png)
+![StackPanel](images/controls/stackpanel/basic.png)
 
 ```fsharp
 StackPanel.create [
@@ -62,7 +62,7 @@ StackPanel.create [
 
 **Example**
 
-![StackPanel Spacing](/images/controls/stackpanel/spacing.png)
+![StackPanel Spacing](images/controls/stackpanel/spacing.png)
 
 ```fsharp
 StackPanel.create [


### PR DESCRIPTION
The doc pages are on a subpath of the domain, therefore I have to use a relative path.
(base href is overwritten)