### PR TITLE
add basic component docs

### DIFF
--- a/src/guides/Components.md
+++ b/src/guides/Components.md
@@ -1,0 +1,83 @@
+---
+layout: guide
+title: Components
+author: Avalonia Community
+list-order: 4
+guide-category: beginner
+---
+
+[hooks]: guides/Hooks.html
+
+While MVU suits for many simple scenarios, there is some friction with bigger projects, scaling up past a few child pages can create a lot of boilerplate for Avalonia Applications.
+
+From v0.5.0 and onwards Avalonia.FuncUI offers a completely new programming model inspited in web frameworks like React and Sutil.
+
+Creating a component is done in the following way
+
+```fsharp
+// An Instance of a Component (which can be used on plain avalonia component instances)
+Component(fun context -> TextBlock.create [ TextBlock.text "That's it!" ])
+// and Component.create which can be used to create DSL compatible components
+Component.create("an identifier", fun context -> TextBlock.create [ TextBlock.text "That's it!" ])
+```
+
+let's check a more complete example and how you can setup your new components within FuncUI applications.
+
+```fsharp
+open Avalonia
+open Avalonia.Controls
+
+open Avalonia.FuncUI
+open Avalonia.FuncUI.DSL
+open Avalonia.FuncUI.Hosts
+
+
+let counter (id: string) (initial: int)=
+    // Component id creates a DSL compatible  version which
+    // you can use on any of your existing views
+    Component.create(id, fun ctx ->
+        let state = ctx.useState initial
+
+        // The rest of the DSL
+        StackPanel.create [
+            StackPanel.children [
+                TextBlock.create [
+                    TextBlock.text (string state.Current)
+                ]
+                Button.create [
+                    Button.width 64
+                    Button.content "Increment"
+                    Button.onClick (fun _ -> state.Current + 1 |> state.Set)
+                ]
+            ]
+        ]
+    )
+
+let view =
+    // Component creates an instance that can be assigned to
+    // Any other Avalonia component's Content
+    Component(fun ctx ->
+        StackPanel.create [
+            StackPanel.children [
+                TextBlock.create [
+                    TextBlock.text "We Can still use our existing components"
+                ]
+                counter "counter-1" 0
+                counter "counter-2" 100
+            ]
+        ]
+    )
+
+type MainWindow() as this =
+    inherit HostWindow()
+    do
+        base.Title <- "Basic Component Example"
+        base.Width <- 400.0
+        base.Height <- 400.0
+        // Note this line
+        this.Content <- Counter.view
+```
+
+### Looking for more advanced uses?
+
+For more Advanced uses check [Hooks]

--- a/src/guides/Components.md
+++ b/src/guides/Components.md
@@ -10,7 +10,7 @@ guide-category: beginner
 
 While MVU suits for many simple scenarios, there is some friction with bigger projects, scaling up past a few child pages can create a lot of boilerplate for Avalonia Applications.
 
-From v0.5.0 and onwards Avalonia.FuncUI offers a completely new programming model inspited in web frameworks like React and Sutil.
+From v0.5.0 and onwards Avalonia.FuncUI offers a completely new programming model inspired by web frameworks like React and Sutil.
 
 Creating a component is done in the following way
 

--- a/src/guides/Hooks.md
+++ b/src/guides/Hooks.md
@@ -1,0 +1,145 @@
+---
+layout: guide
+title: Hooks
+author: Avalonia Community
+list-order: 5
+guide-category: beginner
+---
+
+[components]: guides/Components.html
+
+> Hooks can only be used with [Components], so feel free to check them out first before reviewing this page.
+
+## useState
+
+This is the most basic hook which allows you to create an instance of a value which can be both read and updated in your component's code, the state is kept between renders and any updates to it will cause it to re-render by default
+
+```fsharp
+Component(fun ctx ->
+    let state = ctx.useState 0
+    // Component's UI
+)
+```
+
+## useElmish
+
+WIP
+
+## useEffect
+
+WIP
+
+## IReadable<'T>
+
+```fsharp
+type IReadable<'value> =
+    inherit IAnyReadable
+    abstract member Current: 'value with get
+    abstract member Subscribe : ('value -> unit) -> IDisposable
+```
+
+As is in the source comments:
+
+> Readable state value that can be subscribed to.
+
+Readables are values which you can subscribe to get updates, this are common values used
+
+An example would be the following
+
+```fsharp
+Component(fun ctx ->
+    let state = ctx.useState 0
+
+    Button.create [
+        Button.content $"Count: {state.Current}"
+    ]
+)
+```
+
+At this point this component will be pretty much static, it won't ever be re-rendered because there are no changes to it's state.
+
+## IWritable<'T>
+
+```fsharp
+type IWritable<'value> =
+    inherit IReadable<'value>
+    abstract member Set : 'value -> unit
+```
+
+As is in the source comments:
+
+> Readable and writable state value that can be subscribed to.
+
+If we take the previous example and add mutations it would look like the following:
+
+```fsharp
+Component(fun ctx ->
+    let state = ctx.useState 0
+
+    Button.create [
+        Button.content $"Count: {state.Current}"
+        Button.onClick (fun _ -> state.Current + 1 |> state.Set)
+    ]
+)
+```
+
+### Passed Values
+
+Sometimes when you already have an `IWritable<'T>` value, you would like to use it on sibling components so they can show the same data in different formats or just to communicate changes between different component trees without having to drill the values into the component's tree.
+
+For that we can use Passed Values.
+
+```fsharp
+
+let ComponentA id (value: IWrittable<string>) =
+    Component(id, fun ctx ->
+        // Right here we can use ctx.usePassed to ensure we can both read/update a value
+        let value = ctx.usePassed value
+        StackPanel.create [
+            StackPanel.children [
+                TextBlock.create [
+                    TextBlock.text $"This component can read and update this value: \"{value.Current}\""
+                ]
+                Button.create [
+                    Button.content "Add 3"
+                    Button.onClick (fun _ -> $"{value.Current}3" |> value.Set )
+                ]
+            ]
+        ]
+    )
+
+let ComponentB id (value: IReadable<string>) =
+    Component(id, fun ctx ->
+        // Right here we can use ctx.usePassedRead to ensure we can only read a value
+        let value = ctx.usePassedRead value
+        StackPanel.create [
+            StackPanel.children [
+                TextBlock.create [
+                    TextBlock.text $"This component can only read this value: \"{value.Current}\""
+                ]
+            ]
+        ]
+    )
+
+let View =
+    Component(fun ctx ->
+        let value = ctx.useState "This is my value"
+        StackPanel.create [
+            StackPanel.spacing 12.
+            StackPanel.children [
+                // here we can use our components with the existing value
+                // in other implementations these could also be called
+                // "Stores"
+                ComponentA "component-a" value
+                ComponentB "component-b" value
+                Button.create [
+                    Button.content "I can add 4 from outside"
+                    // since state is both readable and writable we can also
+                    // modify the values from outside the children components
+                    // as usual
+                    Button.onClick (fun _ -> $"{value.Current}4" |> value.Set )
+                ]
+            ]
+        ]
+    )
+```

--- a/src/guides/Unit-Testing-Avalonia-FuncUI-Apps.md
+++ b/src/guides/Unit-Testing-Avalonia-FuncUI-Apps.md
@@ -6,16 +6,16 @@ list-order: 5
 guide-category: beginner
 ---
 
-[Full Template]: guides/Full-Template.html
-[Expecto]: https://github.com/haf/expecto
+[full template]: guides/Full-Template.html
+[expecto]: https://github.com/haf/expecto
 
 Testing `Avalonia.FuncUI apps` is pretty simple if you have previous experience using Elmish it should be not much different
 for the moment let's dive into it.
 
 > **Note**: For this document, we'll use [Expecto] unit test library.
 
-
 I'm using Powershell Core but feel free to follow on the terminal you like most (if it's bash like remember to change `;` for `&`)
+
 ```
 PS ~/github> mkdir TestingExample; cd TestingExample
 
@@ -34,6 +34,7 @@ PS ~/github/TestingExample> dotnet add TestingExample.Tests reference TestingExa
 Reference `..\TestingExample\TestingExample.fsproj` added to the project.
 
 ```
+
 This gives us a [Full Template] and a Expecto project to start our testing.
 
 First, let's replace the default content of the tests inside `TestingExample.Tests.Sample.fs` with the following
@@ -106,6 +107,7 @@ module Counter =
 ```
 
 let's start adding test cases, `Increment` first:
+
 ```fsharp
 module Tests
 
@@ -123,7 +125,9 @@ let tests =
                 updateMessages |> List.fold (fun state message -> Counter.update message state) initialState
             Expect.equal actual.count 2 "Expected count to be 2" ]
 ```
+
 If you run that code with `dotnet test` right now you will get a failure
+
 ```
 Microsoft (R) Test Execution Command Line Tool Version 16.3.0
 Copyright (c) Microsoft Corporation.  All rights reserved.
@@ -145,7 +149,9 @@ Total tests: 1
      Passed: 0
      Failed: 1
 ```
+
 the simple fix is to change this line
+
 ```fsharp
 let initialState: Counter.State = { count = 1 }
 ```
@@ -157,6 +163,7 @@ let initialState: Counter.State = { count = 0 }
 ```
 
 If you run `dotnet test` again
+
 ```
 Microsoft (R) Test Execution Command Line Tool Version 16.3.0
 Copyright (c) Microsoft Corporation.  All rights reserved.
@@ -170,6 +177,7 @@ Test Run Successful.
 Total tests: 1
      Passed: 1
 ```
+
 let's add the `Decrement` test
 
 ```fsharp
@@ -190,9 +198,11 @@ let tests =
                   updateMessages |> List.fold (fun state message -> Counter.update message state) initialState
               Expect.equal actual.count -2 "Expected count to be -2" ]
 ```
+
 Pretty simple huh?
 
 Let's add the `Reset` test case
+
 ```fsharp
 module Tests
 
@@ -210,11 +220,13 @@ let tests =
               let actual = Counter.update Counter.Reset initialState
               Expect.equal actual.count 0 "Expected count to be 0" ]
 ```
+
 the advantage of having a central place to do updates and that we always return a `State` is that we can provide the exact state we want and have a predictable test ouput.
 
 You don't need to provide a list of `Msg`'s but here we put a simple example on how can you provide a set of "steps" to archieve a specific state, this could be useful to you if you need to test a specific workflow or something similar.
 
 Lastly, Here's the full suite of tests.
+
 ```fsharp
 module Tests
 

--- a/src/guides/Views-and-Attributes.md
+++ b/src/guides/Views-and-Attributes.md
@@ -2,9 +2,10 @@
 layout: guide
 title: Views And Attributes
 author: Avalonia Community
-list-order: 4
+list-order: 3
 guide-category: beginner
 ---
+
 F# is a great language to build DSLs (Domain Specific Languages), this library contains an [elm like](https://package.elm-lang.org/packages/elm/html/latest/) DSL used to describe Views.
 
 ```fsharp
@@ -37,6 +38,7 @@ let view (state: CounterState) (dispatch): View =
 # 🔰 Basics
 
 Support for all Avalonia Controls is built-in. You can use them like this:
+
 > **{ControlName}**.create [ **{ControlName}**.**{attributeName}** ]
 
 ```fsharp
@@ -67,11 +69,15 @@ TextBlock.margin (horizontal = 5.0, vertical = 5.0)
 TabControl.margin (5.0, 5.0, 5.0, 5.0)
 ListBox.margin (left = 5.0, top = 5.0, right = 5.0, bottom = 5.0)
 ```
+
 Pretty neat, Hah. Those overloads exist for a lot of attributes (you can also add them yourself), my favorite one is:
+
 ```
 Button.background "green" // or "#00ff00"
 ```
+
 ## 🔧 Properties
+
 For each .NET Property defined on an Avalonia Control there is a corresponding Attribute. Most of them are Property Attributes, but not all of them.
 
 ```fsharp
@@ -83,8 +89,11 @@ Button.create [
 ```
 
 ## ⚡ Events
+
 Events are just like other attributes. You can easily recognize them by their prefix. Events are named like this
+
 > **{ControlName}**.on**{EventName}**
+
 ```fsharp
 Button.onClick (fun args -> // do something )
 TextBox.onKeyDown (fun args -> // do something )
@@ -92,22 +101,29 @@ TextBox.onKeyUp (fun args -> // do something )
 ListBox.onSelectionChanged (fun args -> // do something )
 ...
 ```
+
 ## 🧲 Attached Properties
+
 Attached Attributes are used like Events and normal Properties.
+
 > **{ControlName}**.**{name}**
+
 ```fsharp
 StackPanel.dock Dock.Top
 StackPanel.row 1
 StackPanel.column 1
 ...
 ```
+
 > ⚠ Currently not all attached properties are supported / declared. This is currently in process, feel free to create an issue if something is missing
 
 ## 📦 Content Properties
+
 Content Properties are attributes containing either a single View or a list of Views. They are often named `content`, `children`, `viewItems`, … you get it.
 
 Here are some examples.
-``` fsharp
+
+```fsharp
 // single view content
 Button.create [
     // takes 'View'


### PR DESCRIPTION
@JaggerJo @JordanMarr @sleepyfran

I Know we're still discussing about what we're going to do with the docs, but in the meantime I'd like to have at least some very basic `Component` docs out.

I would like if possible help writing the hooks docs specially `useElmish` (which can be in a different PR)

Please let me know if this is good enough to merge them (we've done WIP parts before so I don't think it should be an issue) or what other changes can we make to merge these