### PR TITLE
Added Most Control Documentation

### DIFF
--- a/src/controls/Border.md
+++ b/src/controls/Border.md
@@ -3,14 +3,15 @@ layout: control
 name: Border
 group: controls
 ---
-[Border]: https://avaloniaui.net/docs/controls/border
-[Views and Attributes]: guides/Views-and-Attributes.html
+[Border]: https://docs.avaloniaui.net/docs/controls/border
+[Border API]: http://reference.avaloniaui.net/api/Avalonia.Controls/Border/
 [Border.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Border.fs
+[Views and Attributes]: guides/Views-and-Attributes.html
 [IBrush]: http://reference.avaloniaui.net/api/Avalonia.Media/IBrush/
 [Thickness]: http://reference.avaloniaui.net/api/Avalonia/Thickness/
 [Corner Radius]: http://reference.avaloniaui.net/api/Avalonia/CornerRadius/
 
-> *Note*: You can check the Avalonia docs for the [Border] if you need more information.
+> *Note*: You can check the Avalonia docs for the [Border] and [Border Api] if you need more information.
 >
 > For Avalonia.FuncUI's DSL properties you can check [Border.fs]
 

--- a/src/controls/Button.md
+++ b/src/controls/Button.md
@@ -5,15 +5,9 @@ group: controls
 ---
 [Button]: https://docs.avaloniaui.net/docs/controls/button
 [Button API]: http://reference.avaloniaui.net/api/Avalonia.Controls/Button/
+[Button.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Button.fs
 [Views and Attributes]: guides/Views-and-Attributes.html
 [Click Mode]: http://reference.avaloniaui.net/api/Avalonia.Controls/ClickMode/
-[Button.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Button.fs
-[ToggleButton]: https://docs.avaloniaui.net/docs/controls/togglebutton
-[ToggleButton API]: http://reference.avaloniaui.net/api/Avalonia.Controls/ToggleButton/
-[ToggleButton.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/ToggleButton.fs
-[RepeatButton]: https://docs.avaloniaui.net/docs/controls/repeatbutton
-[RepeatButton API]: http://reference.avaloniaui.net/api/Avalonia.Controls/RepeatButton/
-[RepeatButton.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/RepeatButton.fs
 
 > *Note*: You can check the Avalonia docs for the [Button] and [Button API] if you need more information.
 >

--- a/src/controls/Button.md
+++ b/src/controls/Button.md
@@ -3,12 +3,19 @@ layout: control
 name: Button
 group: controls
 ---
-[Button]: https://avaloniaui.net/docs/controls/button
+[Button]: https://docs.avaloniaui.net/docs/controls/button
+[Button API]: http://reference.avaloniaui.net/api/Avalonia.Controls/Button/
 [Views and Attributes]: guides/Views-and-Attributes.html
 [Click Mode]: http://reference.avaloniaui.net/api/Avalonia.Controls/ClickMode/
 [Button.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Button.fs
+[ToggleButton]: https://docs.avaloniaui.net/docs/controls/togglebutton
+[ToggleButton API]: http://reference.avaloniaui.net/api/Avalonia.Controls/ToggleButton/
+[ToggleButton.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/ToggleButton.fs
+[RepeatButton]: https://docs.avaloniaui.net/docs/controls/repeatbutton
+[RepeatButton API]: http://reference.avaloniaui.net/api/Avalonia.Controls/RepeatButton/
+[RepeatButton.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/RepeatButton.fs
 
-> *Note*: You can check the Avalonia docs for the [Button] if you need more information.
+> *Note*: You can check the Avalonia docs for the [Button] and [Button API] if you need more information.
 >
 > For Avalonia.FuncUI's DSL properties you can check [Button.fs]
 
@@ -18,19 +25,19 @@ Buttons are basic controls for any application you may build, buttons are often 
 
 > You can check the general usage of Avalonia.FuncUI's views and attributes in the following link [Views and Attributes]
 
-Create a Button
+**Create a Button**
 ```fsharp
 Button.create []
 ```
 
-Register Click
+**Register Click**
 ```fsharp
 Button.create [
 	Button.onClick(fun _ -> dispatch MyMsg)
 ]
 ```
 
-Set Click Mode
+**Set Click Mode**
 ```fsharp
 Button.create [
 	Button.clickMode ClickMode.Press
@@ -42,7 +49,7 @@ Button.create [
 ```
 > for more information check the [Click Mode] docs
 
-Set Content
+**Set Content**
 ```fsharp
 Button.create [ Button.content "My Button" ]
 ```
@@ -63,3 +70,5 @@ Button.create [
 	Button.content iconAndTextBlock
 ]
 ```
+
+

--- a/src/controls/Calendar.md
+++ b/src/controls/Calendar.md
@@ -1,0 +1,62 @@
+---
+layout: control
+name: Calendar
+group: controls
+---
+[Calendar]: https://docs.avaloniaui.net/docs/controls/calendar
+[Calendar API]: http://reference.avaloniaui.net/api/Avalonia.Controls/Calendar/
+[Calendar.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Calendar/Calendar.fs
+[CalendarFormat]: http://reference.avaloniaui.net/api/Avalonia.Controls/CalendarFormat/
+[CalendarMode]: http://reference.avaloniaui.net/api/Avalonia.Controls/CalendarMode/
+[SelectionModes API]: http://reference.avaloniaui.net/api/Avalonia.Controls/SelectionMode/
+[ListBox Selection Modes]: https://docs.avaloniaui.net/docs/controls/listbox#selectionmode
+
+> *Note*: You can check the Avalonia docs for the [Calendar] and [Calendar API] if you need more information.
+>
+> For Avalonia.FuncUI's DSL properties you can check [Calendar.fs]
+
+The Calendar control is a standard Calendar control for users to select date(s) or date ranges.
+
+## Usage
+
+**Set a Date**
+
+If no calendar date is set, it will default to today's date.
+
+```fsharp
+Calendar.create [
+    Calendar.selectedDate DateTime.Today
+]
+```
+
+**Select Multiple Dates**
+
+For more information about selection modes you can see the [SelectionModes API]
+but more verbosely you can look at the [ListBox Selection Modes] for a better
+description of what they do.
+
+```fsharp
+Calendar.create [
+    Calendar.selectionMode SelectionMode.Multiple
+]
+```
+
+**Select Calendar Month First**
+
+You can change the [CalendarMode] so that you can select the year first with 
+`CalendarMode.Decade`, the month first with `CalendarMode.Year`, or have the
+standard (default) format with `CalendarMode.Month`.jok
+
+```fsharp
+Calendar.create [
+    Calendar.displayMode CalendarMode.Decade
+]
+```
+
+**Display Only the Upcoming Week**
+```fsharp
+Calendar.create [
+    Calendar.displayDateStart DateTime.Today
+    Calendar.displayDateEnd (DateTime.Today + TimeSpan(7, 0, 0, 0, 0)) // TimeSpan constructor for 7 days
+]
+```

--- a/src/controls/CalendarDatePicker.md
+++ b/src/controls/CalendarDatePicker.md
@@ -1,0 +1,77 @@
+---
+layout: control
+name: CalendarDatePicker
+group: controls
+---
+[CalendarDatePicker API]: http://reference.avaloniaui.net/api/Avalonia.Controls/CalendarDatePicker/
+[CalendarDatePicker.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Calendar/CalendarDatePicker.fs
+[Custom date and time format strings]: https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings/
+[DatePickerFormat]: http://reference.avaloniaui.net/api/Avalonia.Controls/DatePickerFormat/
+
+> *Note*: You can check the Avalonia docs for the [CalendarDatePicker API] if you need more information.
+>
+> For Avalonia.FuncUI's DSL properties you can check [CalendarDatePicker.fs]
+
+The CalendarDatePicker control is a single date picker that displays a calendar, it is also possible to enter a date via the TextBox the control has
+
+## Usage
+**Set Date**
+
+```fsharp
+CalendarDatePicker.create [
+    CalendarDatePicker.selectedDate DateTime.Today
+]
+```
+
+**Set DateFormat**
+```fsharp
+CalendarDatePicker.create [
+    CalendarDatePicker.selectedDateFormat DatePickerFormat.Long
+]
+
+CalendarDatePicker.create [
+    CalendarDatePicker.selectedDateFormat DatePickerFormat.Short
+]
+
+CalendarDatePicker.create [
+    CalendarDatePicker.selectedDateFormat DatePickerFormat.Custom
+    // It can be any valid DateFormat string
+    CalendarDatePicker.customDateFormatString "MMMM dd, yyyy"
+]
+```
+> For more information about the CalendarDatePickerFormat check [DatePickerFormat]
+
+>You can check [Custom date and time format strings] Microsoft docs for more information about the format string
+
+**Set Start Display Date**
+
+Sets the first date available to display
+```fsharp
+let startFromYesterday =
+    DateTime.Today.Subtract(TimeSpan.FromDays(1.0))
+CalendarDatePicker.create [
+    CalendarDatePicker.displayDateStart startFromYesterday
+]
+```
+
+**Set End Display Date**
+
+Sets the last date available to display
+```fsharp
+let showUpToTomorrow =
+    DateTime.Today.Add(TimeSpan.FromDays(1.0))
+CalendarDatePicker.create [
+    CalendarDatePicker.displayDateStart showUpToTomorrow
+]
+```
+
+**Set Watermark**
+
+Sets the watermark (placeholder) for the TextBox that is included in this control
+```fsharp
+CalendarDatePicker.create [
+    CalendarDatePicker.watermark "Select a date"
+]
+```
+
+

--- a/src/controls/CheckBox.md
+++ b/src/controls/CheckBox.md
@@ -3,7 +3,7 @@ layout: control
 name: CheckBox
 group: controls
 ---
-[CheckBox]: https://avaloniaui.net/docs/controls/checkbox
+[CheckBox]: https://docs.avaloniaui.net/docs/controls/checkbox
 [CheckBox API]: http://reference.avaloniaui.net/api/Avalonia.Controls/CheckBox/
 [CheckBox.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/CheckBox.fs
 

--- a/src/controls/DatePicker.md
+++ b/src/controls/DatePicker.md
@@ -12,7 +12,7 @@ group: controls
 >
 > For Avalonia.FuncUI's DSL properties you can check [DatePicker.fs]
 
-The DatePicker control is a single date picker that displays a calendar, it is also posible to enter a date via the TextBox the control has
+The DatePicker control is a single date picker that displays a calendar, it is also possible to enter a date via the TextBox the control has
 
 ## Usage
 

--- a/src/controls/DatePicker.md
+++ b/src/controls/DatePicker.md
@@ -3,18 +3,26 @@ layout: control
 name: DatePicker
 group: controls
 ---
+[DatePicker]: https://docs.avaloniaui.net/docs/controls/datepicker
 [DatePicker API]: http://reference.avaloniaui.net/api/Avalonia.Controls/DatePicker/
-[DatePicker.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Calendar/DatePicker.fs
+[DatePicker.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/DatePicker.fs
 [Custom date and time format strings]: https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings/
-[DatePickerFormat]: http://reference.avaloniaui.net/api/Avalonia.Controls/DatePickerFormat/
+[DateTimeOffset]: https://docs.microsoft.com/en-us/dotnet/api/system.datetimeoffset?view=net-6.0
 
-> *Note*: You can check the Avalonia docs for the [DatePicker API] if you need more information.
+> *Note*: You can check the Avalonia docs for the [DatePicker] and [DatePicker API] if you need more information.
 >
 > For Avalonia.FuncUI's DSL properties you can check [DatePicker.fs]
 
 The DatePicker control is a single date picker that displays a calendar, it is also possible to enter a date via the TextBox the control has
 
 ## Usage
+
+**Set Label**
+```fsharp
+DatePicker.create [
+    DatePicker.header "Title"
+]
+```
 
 **Set Date**
 ```fsharp
@@ -26,52 +34,38 @@ DatePicker.create [
 **Set DateFormat**
 ```fsharp
 DatePicker.create [
-    DatePicker.selectedDateFormat DatePickerFormat.Long
-]
-
-DatePicker.create [
-    DatePicker.selectedDateFormat DatePickerFormat.Short
-]
-
-DatePicker.create [
-    DatePicker.selectedDateFormat DatePickerFormat.Custom
-    // It can be any valid DateFormat string
-    DatePicker.customDateFormatString "MMMM dd, yyyy"
-]
-```
-> For more information about the DatePickerFormat check [DatePickerFormat]
-
->You can check [Custom date and time format strings] Microsoft docs for more information about the format string
-
-**Set Start Display Date**
-
-Sets the first date available to display
-```fsharp
-let startFromYesterday =
-    DateTime.Today.Subtract(TimeSpan.FromDays(1.0))
-DatePicker.create [
-    DatePicker.displayDateStart startFromYesterday
+    DatePicker.yearFormat "yyyy"
+    DatePicker.monthFormat "MMMM"
+    DatePicker.dayFormat "dd"
 ]
 ```
 
-**Set End Display Date**
+>You can check [Custom date and time format strings] Microsoft docs for more information about the format strings.
 
-Sets the last date available to display
-```fsharp
-let showUpToTomorrow =
-    DateTime.Today.Add(TimeSpan.FromDays(1.0))
-DatePicker.create [
-    DatePicker.displayDateStart showUpToTomorrow
-]
-```
+**Limit Year Range**
 
-**Set Watermark**
+> You can check [DateTimeOffset] Microsoft docs for more information about setting time offsets.
 
-Sets the watermark (placeholder) for the TextBox that is included in this control
 ```fsharp
 DatePicker.create [
-    DatePicker.watermark "Select a date"
+    DatePicker.maxYear (DateTimeOffset(DateTime.Now))
 ]
 ```
 
+**Show Only Month and Year**
 
+You can control the visibility of the day, month, and year with similarly named functions.
+
+```fsharp
+DatePicker.create [
+    DatePicker.dayVisible false
+]
+```
+
+**Register Selected Date**
+
+```fsharp
+DatePicker.create [
+    DatePicker.onSelectedDateChanged (fun dateOffset -> OnChangeDateOffset dateOffset |> dispatch)
+]
+```

--- a/src/controls/DockPanel.md
+++ b/src/controls/DockPanel.md
@@ -3,7 +3,7 @@ layout: control
 name: DockPanel
 group: controls
 ---
-[DockPanel]: https://avaloniaui.net/docs/controls/dockpanel
+[DockPanel]: https://docs.avaloniaui.net/docs/controls/dockpanel
 [DockPanel API]: http://reference.avaloniaui.net/api/Avalonia.Controls/DockPanel/
 [DockPanel.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Panels/DockPanel.fs
 

--- a/src/controls/Expander.md
+++ b/src/controls/Expander.md
@@ -3,7 +3,7 @@ layout: control
 name: Expander
 group: controls
 ---
-[Expander]: https://avaloniaui.net/docs/controls/expander
+[Expander]: https://docs.avaloniaui.net/docs/controls/expander
 [Expander API]: http://reference.avaloniaui.net/api/Avalonia.Controls/Expander/
 [Expander.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Expander.fs
 

--- a/src/controls/ListBox.md
+++ b/src/controls/ListBox.md
@@ -50,7 +50,6 @@ To override the controls default behavior you need to add both `selectedItem` an
 ListBox.create [
     ListBox.dataItems [ "Linux"; "Mac"; "Windows" ]
     ListBox.selectedItem state.os
-    // remember to use OnChangeOf to give FuncUI hints about when to dispatch the messages
     ListBox.onSelectedItemChanged (fun os -> dispatch ChangeOs)
 ]
 ```
@@ -61,7 +60,6 @@ To override the controls default behavior you need to add both `selectedItem` an
 ListBox.create [
     ListBox.dataItems [ "Linux"; "Mac"; "Windows" ]
     ListBox.selectedIndex state.osIndex
-    // remember to use OnChangeOf to give FuncUI hints about when to dispatch the messages
     ListBox.onSelectedIndexChanged (fun os -> dispatch ChangeOsIndex)
 ]
 ```

--- a/src/controls/ListBox.md
+++ b/src/controls/ListBox.md
@@ -24,6 +24,7 @@ ListBox.create [
 ```
 
 **Multiple Item Selection Mode**
+
 You can choose different [ListBox Selection Modes]. The default is to only select a single element.
 ```fsharp
 ListBox.create [
@@ -45,7 +46,9 @@ ListBox.create [
 ```
 
 **Controlling Selected Item**
+
 To override the controls default behavior you need to add both `selectedItem` and `onSelectedItemChanged`
+
 ```fsharp
 ListBox.create [
     ListBox.dataItems [ "Linux"; "Mac"; "Windows" ]
@@ -55,7 +58,9 @@ ListBox.create [
 ```
 
 **Controlling Selected Item by Index**
+
 To override the controls default behavior you need to add both `selectedItem` and `onSelectedItemChanged`
+
 ```fsharp
 ListBox.create [
     ListBox.dataItems [ "Linux"; "Mac"; "Windows" ]

--- a/src/controls/ListBox.md
+++ b/src/controls/ListBox.md
@@ -16,7 +16,7 @@ The list box is a multi-line control box for allowing a user to choose value.
 
 ## Usage
 
-**Basic**
+**Create a list box**
 ```fsharp
 ListBox.create [
     ListBox.dataItems [ "Linux"; "Mac"; "Windows" ]

--- a/src/controls/ListBox.md
+++ b/src/controls/ListBox.md
@@ -1,0 +1,67 @@
+---
+layout: control
+name: ListBox
+group: controls
+---
+[ListBox]: https://docs.avaloniaui.net/docs/controls/listbox
+[ListBox API]: http://reference.avaloniaui.net/api/Avalonia.Controls/ListBox/
+[ListBox.fs]: https://github.com/fsprojects/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/ListBox.fs
+[ListBox Selection Modes]: https://docs.avaloniaui.net/docs/controls/listbox#selectionmode
+
+> *Note*: You can check the Avalonia docs for the [ListBox] and [ListBox API] if you need more information.
+>
+> For Avalonia.FuncUI's DSL properties you can check [ListBox.fs]
+
+The list box is a multi-line control box for allowing a user to choose value.
+
+## Usage
+
+**Basic**
+```fsharp
+ListBox.create [
+    ListBox.dataItems [ "Linux"; "Mac"; "Windows" ]
+]
+```
+
+**Multiple Item Selection Mode**
+You can choose different [ListBox Selection Modes]. The default is to only select a single element.
+```fsharp
+ListBox.create [
+    ListBox.dataItems [ "Linux"; "Mac"; "Windows" ]
+    ListBox.selectionMode Selection.Multiple
+]
+```
+
+**Using Discriminated Unions**
+```fsharp
+type OperatingSystem =
+    | Linux
+    | Mac
+    | Windows
+
+ListBox.create [
+    ListBox.dataItems [ Linux; Mac; Windows ]
+]
+```
+
+**Controlling Selected Item**
+To override the controls default behavior you need to add both `selectedItem` and `onSelectedItemChanged`
+```fsharp
+ListBox.create [
+    ListBox.dataItems [ "Linux"; "Mac"; "Windows" ]
+    ListBox.selectedItem state.os
+    // remember to use OnChangeOf to give FuncUI hints about when to dispatch the messages
+    ListBox.onSelectedItemChanged (fun os -> dispatch ChangeOs)
+]
+```
+
+**Controlling Selected Item by Index**
+To override the controls default behavior you need to add both `selectedItem` and `onSelectedItemChanged`
+```fsharp
+ListBox.create [
+    ListBox.dataItems [ "Linux"; "Mac"; "Windows" ]
+    ListBox.selectedIndex state.osIndex
+    // remember to use OnChangeOf to give FuncUI hints about when to dispatch the messages
+    ListBox.onSelectedIndexChanged (fun os -> dispatch ChangeOsIndex)
+]
+```

--- a/src/controls/Menu.md
+++ b/src/controls/Menu.md
@@ -3,9 +3,9 @@ layout: control
 name: Menu
 group: controls
 ---
+[Menu]: http://docs.avaloniaui.net/docs/controls/menu
 [Menu API]: http://reference.avaloniaui.net/api/Avalonia.Controls/Menu/
 [Menu.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Menu.fs
-[Menu]: http://avaloniaui.net/docs/controls/menu
 [Image]: http://avaloniaui.net/docs/controls/image
 [sample]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Examples/Examples.MusicPlayer/Shell.fs#L162
 [this file]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Examples/Examples.MusicPlayer/Extensions.fs#L5

--- a/src/controls/NativeMenu.md
+++ b/src/controls/NativeMenu.md
@@ -3,11 +3,12 @@ layout: control
 name: NativeMenu
 group: controls
 ---
-[NativeMenu]: https://avaloniaui.net/docs/controls/nativemenu
+[NativeMenu]: https://docs.avaloniaui.net/docs/controls/nativemenu
+[NativeMenu API]: http://reference.avaloniaui.net/api/Avalonia.Controls/NativeMenu
 [announcement]: https://avaloniaui.net/blog/#osx-linux-native-menus
 [in this issue]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/issues/113
 
-> You can check the [NativeMenu] Avalonia docs for more information
+> You can check the [NativeMenu] and [NativeMenu API] Avalonia docs for more information
 
 Native menus were introduced in Avalonia in version 0.9.0, you can check the [announcement] to see a brief explanation on how to use them in Avalonia Applications.
 

--- a/src/controls/NumericUpDown.md
+++ b/src/controls/NumericUpDown.md
@@ -16,6 +16,8 @@ The NumericUpDown is an editable numeric input field. The control has a up and d
 increment and decrement the value in the input field. The value can also be incremented or decremented using the arrow
 keys or the mouse wheel when the control is selected.
 
+## Usage
+
 **Input with local currency**
 
 Adding the `NumericUpDown.minimum` or `NumericUpDown.maximum` attributes will limit the input for both button increment/decrement

--- a/src/controls/NumericUpDown.md
+++ b/src/controls/NumericUpDown.md
@@ -1,0 +1,58 @@
+---
+layout: control
+name: NumericUpDown
+group: controls
+---
+[NumericUpDown]: https://docs.avaloniaui.net/docs/controls/numericupdown
+[NumericUpDown API]: http://reference.avaloniaui.net/api/Avalonia.Controls/NumericUpDown/
+[NumericUpDown.fs]: https://github.com/fsprojects/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/NumericUpDown.fs
+[Numeric String Formats]: https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings
+
+> *Note*: You can check the Avalonia docs for the [NumericUpDown] and [NumericUpDown API] if you need more information.
+>
+> For Avalonia.FuncUI's DSL properties you can check [NumericUpDown.fs]
+
+The NumericUpDown is an editable numeric input field. The control has a up and down button spinner attached, used to
+increment and decrement the value in the input field. The value can also be incremented or decremented using the arrow
+keys or the mouse wheel when the control is selected.
+
+**Input with local currency**
+
+Adding the `NumericUpDown.minimum` or `NumericUpDown.maximum` attributes will limit the input for both button increment/decrement
+changes and text input changes.
+
+For more information about rendering the controls value you can check out the documentation for [Numeric String Formats].
+
+```fsharp
+NumericUpDown.create [
+    NumericUpDown.minimum 0.
+    NumericUpDown.maximum 10.
+    NumericUpDown.formatString "C2"
+    NumericUpDown.increment 0.25
+]
+```
+
+**Simple numeric input**
+
+If you want to disable the increment/decrement buttons you can add
+`NumericUpDown.allowSpin false`. If you then also want to remove visibility of the buttons you can
+add `NumericUpDown.showButtonSpinner false`.
+
+```fsharp
+NumericUpDown.create [
+    NumericUpDown.minimum 0.
+    NumericUpDown.minimum 100.
+    NumericUpDown.showButtonSpinner false
+    NumericUpDown.allowSpin false
+]
+```
+
+**State controlled input**
+```fsharp
+NumericUpDown.create [
+    NumericUpDown.minimum 0.
+    NumericUpDown.formatString "C2"
+    NumericUpDown.value state.price
+    NumericUpDown.onValueChanged (fun newPrice -> ChangePrice price |> dispatch )
+]
+```

--- a/src/controls/ProgressBar.md
+++ b/src/controls/ProgressBar.md
@@ -1,0 +1,32 @@
+---
+layout: control
+name: ProgressBar
+group: controls
+---
+[ProgressBar]: https://docs.avaloniaui.net/docs/controls/progressbar
+[ProgressBar API]: http://reference.avaloniaui.net/api/Avalonia.Controls/ProgressBar/
+[ProgressBar.fs]: https://github.com/fsprojects/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/ProgressBar.fs
+
+> *Note*: You can check the Avalonia docs for the [ProgressBar] and [ProgressBar API] if you need more information.
+>
+> For Avalonia.FuncUI's DSL properties you can check [ProgressBar.fs]
+
+The ProgressBar control allow for showing dynamic progress status.
+
+## Usage
+
+**Basic Progress Bar**
+```fsharp
+ProgressBar.create [
+    ProgressBar.value 50.
+    ProgressBar.maximum 100.
+    // Minimum default value is set to 0
+]
+```
+
+**Indeterminate Animated Progress Bar**
+```fsharp
+ProgressBar.create [
+    ProgressBar.isIndeterminate true
+]
+```

--- a/src/controls/RadioButton.md
+++ b/src/controls/RadioButton.md
@@ -3,7 +3,7 @@ layout: control
 name: RadioButton
 group: controls
 ---
-[RadioButton]: https://avaloniaui.net/docs/controls/radiobutton
+[RadioButton]: https://docs.avaloniaui.net/docs/controls/radiobutton
 [RadioButton API]: http://reference.avaloniaui.net/api/Avalonia.Controls/RadioButton/
 [RadioButton.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/RadioButton.fs
 

--- a/src/controls/RepeatButton.md
+++ b/src/controls/RepeatButton.md
@@ -1,0 +1,34 @@
+---
+layout: control
+name: RepeatButton
+group: controls
+---
+[RepeatButton]: https://docs.avaloniaui.net/docs/controls/repeatbutton
+[RepeatButton API]: http://reference.avaloniaui.net/api/Avalonia.Controls/RepeatButton/
+[RepeatButton.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/RepeatButton.fs
+[Views and Attributes]: guides/Views-and-Attributes.html
+[Click Mode]: http://reference.avaloniaui.net/api/Avalonia.Controls/ClickMode/
+
+> *Note*: You can check the Avalonia docs for the [RepeatButton] and [RepeatButton API] if you need more information.
+>
+> For Avalonia.FuncUI's DSL properties you can check [RepeatButton.fs]
+
+
+A `RepeatButton` is a subclasses of [Button] so they share all the same
+attributes as described on that documentation page. The biggest difference is
+that when a `RepeatButton` is held down, the button submits multiple `onClick`
+events.
+
+**Creating a RepeatButton**
+
+The `RepeatButton.delay` sets the amount of time in milliseconds before the
+extra `onClick` events start triggering. The `RepeatButton.interval` sets the
+amount of time in milliseconds between successive `onClick` events
+
+```fsharp
+RepeatButton.create [
+    RepeatButton.delay 100 // ms
+    RepeatButton.interval 250 // ms
+    RepeatButton.onClick (fun _ -> dispatch RepeatButtonCicked)
+]
+```

--- a/src/controls/Slider.md
+++ b/src/controls/Slider.md
@@ -1,0 +1,27 @@
+---
+layout: control
+name: Slider
+group: controls
+---
+[Slider]: https://docs.avaloniaui.net/docs/controls/slider
+[Slider API]: http://reference.avaloniaui.net/api/Avalonia.Controls/Slider/
+[Slider.fs]: https://github.com/fsprojects/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Slider.fs
+[Slider Selection Modes]: https://docs.avaloniaui.net/docs/controls/listbox#selectionmode
+
+> *Note*: You can check the Avalonia docs for the [Slider] and [Slider API] if you need more information.
+>
+> For Avalonia.FuncUI's DSL properties you can check [Slider.fs]
+
+The Slider control is a control that lets the user select from a range of
+values by moving a Thumb control along a track.
+
+**Percentage Slider**
+```fsharp
+Slider.create [
+    Slider.minimum 0.
+    Slider.maximum 0.
+    Slider.value state.Percentage
+    Slider.onValueChanged (fun newPercentage -> ChangePercentage newPercentage |> dispatch)
+
+]
+```

--- a/src/controls/Slider.md
+++ b/src/controls/Slider.md
@@ -15,6 +15,8 @@ group: controls
 The Slider control is a control that lets the user select from a range of
 values by moving a Thumb control along a track.
 
+## Usage
+
 **Percentage Slider**
 ```fsharp
 Slider.create [

--- a/src/controls/StackPanel.md
+++ b/src/controls/StackPanel.md
@@ -3,7 +3,7 @@ layout: control
 name: StackPanel
 group: controls
 ---
-[StackPanel]: https://avaloniaui.net/docs/controls/stackpanel
+[StackPanel]: https://docs.avaloniaui.net/docs/controls/stackpanel
 [StackPanel API]: http://reference.avaloniaui.net/api/Avalonia.Controls/StackPanel/
 [StackPanel.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/Panels/StackPanel.fs
 

--- a/src/controls/Tabs.md
+++ b/src/controls/Tabs.md
@@ -3,14 +3,14 @@ layout: control
 name: TabControl
 group: controls
 ---
+[TabControl]: http://docs.avaloniaui.net/docs/controls/tabcontrol
 [TabControl API]: http://reference.avaloniaui.net/api/Avalonia.Controls/TabControl/
 [TabControl.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/TabControl.fs
-[TabControl]: http://avaloniaui.net/docs/controls/tabcontrol
 [example]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.ControlCatalog/Views/MainView.fs
 [ViewBuilder]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.ControlCatalog/Views/MainView.fs#L36
 [HostControl]: controls/HostControl.html
 
-> *Note*: You can check the Avalonia docs for the [TabControl API] and [TabControl] if you need more information.
+> *Note*: You can check the Avalonia docs for the [TabControl] and [TabControl API] if you need more information.
 >
 > For Avalonia.FuncUI's DSL properties you can check [TabControl.fs]
 

--- a/src/controls/TextBlock.md
+++ b/src/controls/TextBlock.md
@@ -3,7 +3,7 @@ layout: control
 name: TextBlock
 group: controls
 ---
-[TextBlock]: https://avaloniaui.net/docs/controls/textblock
+[TextBlock]: https://docs.avaloniaui.net/docs/controls/textblock
 [TextBlock API]: http://reference.avaloniaui.net/api/Avalonia.Controls/TextBlock/
 [TextBlock.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/TextBlock.fs
 

--- a/src/controls/TextBox.md
+++ b/src/controls/TextBox.md
@@ -3,7 +3,7 @@ layout: control
 name: TextBox
 group: controls
 ---
-[TextBox]: https://avaloniaui.net/docs/controls/textbox
+[TextBox]: https://docs.avaloniaui.net/docs/controls/textbox
 [TextBox API]: http://reference.avaloniaui.net/api/Avalonia.Controls/TextBox/
 [TextBox.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/TextBox.fs
 

--- a/src/controls/TimePicker.md
+++ b/src/controls/TimePicker.md
@@ -1,0 +1,53 @@
+---
+layout: control
+name: TimePicker
+group: controls
+---
+[TimePicker]: https://docs.avaloniaui.net/docs/controls/timepicker
+[TimePicker API]: http://reference.avaloniaui.net/api/Avalonia.Controls/TimePicker/
+[TimePicker.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/TimePicker.fs
+[TimeSpan]: https://docs.microsoft.com/en-us/dotnet/api/system.timespan
+[ClockIdentifier]: https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.timepicker.clockidentifier?view=winrt-19041#Windows_UI_Xaml_Controls_TimePicker_ClockIdentifier
+
+> *Note*: You can check the Avalonia docs for the [TimePicker] and [TimePicker API] if you need more information.
+>
+> For Avalonia.FuncUI's DSL properties you can check [TimePicker.fs]
+
+The TimePicker control allows the user to pick a time value.
+
+## Usage
+
+**Create a TimePicker**
+```fsharp
+TimePicker.create [
+    TimePicker.header "Arrival Time"
+]
+```
+
+**Change in 15 Minute Increments**
+```fsharp
+TimePicker.create [
+    TimePicker.header "Arrival Time"
+    TimePicker.minuteIncrement 15
+]
+```
+
+**Choose a 12 or 24 Hour Clock**
+
+For more information about the attribute values here you can check out the
+documentation for [TimeSpan] and the [ClockIdentifier].
+
+```fsharp
+TimePicker.create [
+    TimePicker.header "12 Hour Clock"
+    TimePicker.selectedTime (TimeSpan(14, 30, 0))
+    TimePicker.clockIdentifier "12HourClock"
+]
+
+TimePicker.create [
+    TimePicker.header "24 Hour Clock"
+    TimePicker.selectedTime (TimeSpan(14, 30, 0))
+    TimePicker.clockIdentifier "24HourClock"
+]
+```
+

--- a/src/controls/ToggleButton.md
+++ b/src/controls/ToggleButton.md
@@ -59,8 +59,8 @@ ToggleButton.create [
     // this value is required to be either a nullable boolean
     // or a boolean option
     ToggleButton.isChecked state.checked
-    // Returns a Nullable<boo> value
-    ToggleButton.onIsCheckedChanged (fun nullabelVal -> OnChecked val |> dispatch
+    // Returns a Nullable<bool> value
+    ToggleButton.onIsCheckedChanged (fun nullabelVal -> OnChecked val |> dispatch)
 ]
 ```
 

--- a/src/controls/ToggleButton.md
+++ b/src/controls/ToggleButton.md
@@ -1,0 +1,66 @@
+---
+layout: control
+name: ToggleButton
+group: controls
+---
+[ToggleButton]: https://docs.avaloniaui.net/docs/controls/togglebutton
+[ToggleButton API]: http://reference.avaloniaui.net/api/Avalonia.Controls.Primitives/ToggleButton/
+[ToggleButton.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/ToggleButton.fs
+[Views and Attributes]: guides/Views-and-Attributes.html
+[Click Mode]: http://reference.avaloniaui.net/api/Avalonia.Controls/ClickMode/
+[Button]: controls/Button.html
+[CheckBox]: controls/CheckBox.html
+
+> *Note*: You can check the Avalonia docs for the [ToggleButton] and [ToggleButton API] if you need more information.
+>
+> For Avalonia.FuncUI's DSL properties you can check [ToggleButton.fs]
+
+If you are looking for a button to behave more like a checkbox you can use a
+`ToggleButton`. A `ToggleButton` toggles between checked and unchecked on click.
+
+A `ToggleButton` is a subclasses of [Button] so they share all the same
+attributes as described on that documentation page. A `ToggleButton` behaves
+similar to a [CheckBox] and shares similar attributes like making tristate
+ToggleButtons.
+
+> You need to `open Avaloina.Controls.Primatives` to access `ToggleButton` attributes.
+
+## Usage
+
+**Toggling for Checked/Unchecked**
+
+```fsharp 
+ToggleButton.create [
+    ToggleButton.isChecked state.checked
+    // Returns a bool value
+    ToggleButton.onIsPressedChanged (fun val -> OnChecked val |> dispatch)
+]
+```
+
+**Handling Checked and Unchecked Differently**
+```fsharp 
+ToggleButton.create [
+    ToggleButton.onChecked (fun _ -> dispatch Enabled)
+    ToggleButton.onUnchecked (fun _ -> dispatch Disabled)
+]
+```
+
+**Tristate Toggling**
+
+`ToggleButton.isChecked` can take values that are `bool`, `Nullable<bool>`, or
+`bool option`. When using tristate options however, you must use either
+`Nullable<bool>` or `bool option`. You can also handle each event state like
+above using `onChecked`, `onUncheked`, and `onIndeterminate`.
+
+```fsharp 
+ToggleButton.create [
+    // can be either true or false
+    ToggleButton.isThreeState state.indeterminate
+    // this value is required to be either a nullable boolean
+    // or a boolean option
+    ToggleButton.isChecked state.checked
+    // Returns a Nullable<boo> value
+    ToggleButton.onIsCheckedChanged (fun nullabelVal -> OnChecked val |> dispatch
+]
+```
+

--- a/src/controls/ToggleSwitch.md
+++ b/src/controls/ToggleSwitch.md
@@ -1,0 +1,69 @@
+---
+layout: control
+name: ToggleSwitch
+group: controls
+---
+[ToggleSwitch API]: http://reference.avaloniaui.net/api/Avalonia.Controls/ToggleSwitch/
+[ToggleSwitch.fs]: https://github.com/AvaloniaCommunity/Avalonia.FuncUI/blob/master/src/Avalonia.FuncUI.DSL/ToggleSwitch.fs
+[Views and Attributes]: guides/Views-and-Attributes.html
+[Click Mode]: http://reference.avaloniaui.net/api/Avalonia.Controls/ClickMode/
+[CheckBox]: controls/CheckBox.html
+
+> *Note*: You can check the Avalonia docs for the [ToggleSwitch API] if you need more information.
+>
+> For Avalonia.FuncUI's DSL properties you can check [ToggleSwitch.fs]
+
+A `ToggleSwitch` is a switch that toggles between on (checked) and off
+(unchecked) states. This control functions similarly to a [CheckBox] but
+displays the content with an on/off slider instead.
+
+## Usage
+
+**Create a ToggleSwitch**
+
+```fsharp
+ToggleSwitch.create [
+    ToggleSwitch.content "Title"
+]
+```
+
+**Register State Change**
+
+```fsharp
+ToggleSwitch.create [
+    ToggleSwitch.isChecked state.toggleSwitch
+    ToggleSwitch.onIsPressedChanged (fun value -> SwitchToggled value |> dispatch)
+]
+```
+
+**Handle state changes Separately**
+
+```fsharp
+ToggleSwitch.create [
+    ToggleSwitch.content "Fullscreen"
+    ToggleSwitch.onChecked (fun _ -> dispatch Fullscreen)
+    ToggleSwitch.onUnchecked (fun _ -> dispatch Windowed)
+]
+```
+
+**Tristate Toggling**
+
+`ToggleSwitch.isChecked` can take values that are `bool`, `Nullable<bool>`, or
+`bool option`. When using tristate options however, you must use either
+`Nullable<bool>` or `bool option`. You can also handle each event state like
+above using `onChecked`, `onUncheked`, and `onIndeterminate`.
+
+```fsharp 
+ToggleSwitch.create [
+    // can be either true or false
+    ToggleSwitch.isThreeState state.indeterminate
+    // this value is required to be either a nullable boolean
+    // or a boolean option
+    ToggleSwitch.isChecked state.checked
+    // Returns a Nullable<bool> value
+    ToggleSwitch.onIsCheckedChanged (fun nullabelVal -> OnChecked val |> dispatch)
+]
+```
+
+
+


### PR DESCRIPTION
This pull request is to help fill out some of the missing control documentation as mentioned in issue #1.

* **Fixed Broken Links** caused by URL change of http://reference.avaloniaui.net/ to http://docs.reference.avaloniaui.net/
* **DatePicker** moved to **CalendarDatePicker**
* **Updated styling** to be more conferment with the rest of the component docs
* **Added New Controls**
  * ListBox
  * Slider
  * NumericUpDown
  * TimePicker
  * Calendar
  * ToggleButton
  * RepeatButton
  * ToggleSwitch
  * DatePicker (new component)

Feel free to give feedback on any of component tutorials I created.